### PR TITLE
Add subcategory

### DIFF
--- a/config.lisp.in
+++ b/config.lisp.in
@@ -3,11 +3,15 @@
         :parenscript
         :ps-experiment)
   (:export :get-config-list
-           :get-body-template))
+           :get-body-template
+           :get-const
+           :get-config))
 (in-package :cl-gas-nippo/config)
 
 (defvar.ps+ *config-list*
     '((:spreadsheet-id "XXXX")
+      (:sheet-name-nippo "日報用")
+      (:sheet-name-nippo-log "日報ログ")
       (:to "to-example@example.com")
       (:cc "cc-example@example.com")
       (:bcc "bcc-example@example.com")

--- a/src/const.lisp
+++ b/src/const.lisp
@@ -7,10 +7,9 @@
 
 (defvar.ps+ *const-table*
     (let ((res (make-hash-table))
-          (lst '((:sheet-name-nippo "日報用")
-                 (:sheet-name-nippo-log "日報ログ")
-                 (:column-name-date "Date")
+          (lst '((:column-name-date "Date")
                  (:column-name-category "Category")
+                 (:column-name-subcategory "Subcategory")
                  (:column-name-content "Content")
                  (:category-do "やること")
                  (:log-name-done "やったこと")

--- a/src/content-info.lisp
+++ b/src/content-info.lisp
@@ -6,7 +6,8 @@
            :find-category-info
            :do-subcategory
            :category-info-contents
-           :push-content-row)
+           :push-content-row
+           :category-info)
   (:import-from :alexandria
                 :with-gensyms))
 (in-package :cl-gas-nippo/src/content-info)
@@ -45,9 +46,10 @@
 
 (defun.ps+ category-info-contents (category-info)
   (let ((result (list)))
-    (dolist (subc-info (category-info-subcategory-info-list category-info))
+    (dolist (subc-info (reverse (category-info-subcategory-info-list category-info)))
       (setf result
-            (append result (subcategory-info-contents subc-info))))))
+            (append result (reverse (subcategory-info-contents subc-info)))))
+    result))
 
 (defmacro.ps+ do-subcategory (((var-name var-contents) category-info) &body body)
   (with-gensyms (subc-info)

--- a/src/content-info.lisp
+++ b/src/content-info.lisp
@@ -1,0 +1,82 @@
+(defpackage cl-gas-nippo/src/content-info
+  (:use :cl
+        :ps-experiment
+        :parenscript)
+  (:export :make-category-info-list
+           :find-category-info
+           :do-subcategory
+           :category-info-contents
+           :push-content-row)
+  (:import-from :alexandria
+                :with-gensyms))
+(in-package :cl-gas-nippo/src/content-info)
+
+;; --- types --- ;;
+
+(defstruct.ps+ subcategory-info
+  name
+  ;; Use list not to change order
+  contents)
+
+(defstruct.ps+ category-info
+  name
+  ;; Use list not to change order
+  subcategory-info-list)
+
+;; --- export --- ;;
+
+(defun.ps+ make-category-info-list ()
+  ;; empty list
+  (list))
+
+(defun.ps+ push-content-row (&key category-info-list category subcategory content)
+  (let* ((c-info (find-or-create-category-info
+                  category-info-list
+                  category))
+         (subc-info (find-or-create-subcategory-info
+                     (category-info-subcategory-info-list c-info)
+                     subcategory)))
+    (push content (subcategory-info-contents subc-info))))
+
+(defun.ps+ find-category-info (category-info-list category)
+  (find-if (lambda (info)
+             (string= (category-info-name info) category))
+           category-info-list))
+
+(defun.ps+ category-info-contents (category-info)
+  (let ((result (list)))
+    (dolist (subc-info (category-info-subcategory-info-list category-info))
+      (setf result
+            (append result (subcategory-info-contents subc-info))))))
+
+(defmacro.ps+ do-subcategory (((var-name var-contents) category-info) &body body)
+  (with-gensyms (subc-info)
+    `(dolist (,subc-info (reverse (category-info-subcategory-info-list ,category-info)))
+       (let ((,var-name (subcategory-info-name ,subc-info))
+             (,var-contents (reverse (subcategory-info-contents ,subc-info))))
+         ,@body))))
+
+;; --- internal --- ;;
+
+(defun.ps+ find-or-create-category-info (category-info-list category)
+  (let ((info (find-category-info category-info-list category)))
+    (unless info
+      (setf info (make-category-info
+                  :name category
+                  :subcategory-info-list (list)))
+      (push info category-info-list))
+    info))
+
+(defun.ps+ find-subcategory-info (subcategory-info-list subcategory)
+  (find-if (lambda (info)
+             (string= (subcategory-info-name info) subcategory))
+           subcategory-info-list))
+
+(defun.ps+ find-or-create-subcategory-info (subcategory-info-list subcategory)
+  (let ((info (find-subcategory-info subcategory-info-list subcategory)))
+    (unless info
+      (setf info (make-subcategory-info
+                  :name subcategory
+                  :contents (list)))
+      (push info subcategory-info-list))
+    info))

--- a/src/init.lisp
+++ b/src/init.lisp
@@ -3,6 +3,8 @@
         :ps-experiment
         :parenscript)
   (:export :init)
+  (:import-from :cl-gas-nippo/config
+                :get-config)
   (:import-from :cl-gas-nippo/src/const
                 :get-const)
   (:import-from :cl-gas-nippo/src/utils/sheet
@@ -13,11 +15,11 @@
 (defun.ps+ init ()
   (let ((ss (get-spreadhsheet)))
     (multiple-value-bind (sheet existing-p)
-        (get-or-create-sheet ss (get-const :sheet-name-nippo-log))
+        (get-or-create-sheet ss (get-config :sheet-name-nippo-log))
       (unless existing-p
         (init-nippo-log-sheet sheet)))
     (multiple-value-bind (sheet existing-p)
-        (get-or-create-sheet ss (get-const :sheet-name-nippo))
+        (get-or-create-sheet ss (get-config :sheet-name-nippo))
       (unless existing-p
         (init-nippo-sheet sheet)))))
 
@@ -28,7 +30,8 @@
   (init-nippo-sheet-header sheet))
 
 (defun.ps init-nippo-sheet-header (sheet)
-  (chain (sheet.get-range "A1:C1")
+  (chain (sheet.get-range "A1:D1")
          (set-values (list (list (get-const :column-name-date)
                                  (get-const :column-name-category)
+                                 (get-const :column-name-subcategory)
                                  (get-const :column-name-content))))))

--- a/src/nippo-content.lisp
+++ b/src/nippo-content.lisp
@@ -5,8 +5,16 @@
   (:export :make-content)
   (:import-from :cl-gas-nippo/src/aggregate
                 :aggregate)
+  (:import-from :cl-gas-nippo/config
+                :get-config)
   (:import-from :cl-gas-nippo/src/const
                 :get-const)
+  (:import-from :cl-gas-nippo/src/content-info
+                :make-category-info-list
+                :find-category-info
+                :do-subcategory
+                :category-info-contents
+                :push-content-row)
   (:import-from :cl-gas-nippo/src/utils/config
                 :check-if-other-category
                 :get-title-of-category
@@ -30,46 +38,70 @@
 
 (defun.ps make-content (now)
   (let* ((sheet (get-sheet (get-spreadhsheet)
-                           (get-const :sheet-name-nippo)))
+                           (get-config :sheet-name-nippo)))
          (date-index (get-column-index-by-name
                       sheet (get-const :column-name-date)))
          (category-index (get-column-index-by-name
                           sheet (get-const :column-name-category)))
+         (subcategory-index (get-column-index-by-name
+                             sheet (get-const :column-name-subcategory)))
          (content-index (get-column-index-by-name
                          sheet (get-const :column-name-content)))
          (last-row (sheet.get-last-row))
-         (today-contents (list))
-         (next-contents (list))
-         (other-contents-table (make-hash-table))
+         (today-category-info-list (make-category-info-list))
+         (next-category-info-list (make-category-info-list))
          (today (get-today-date)))
     (multiple-value-bind (start-row end-row)
         (find-today-and-next-rows sheet today date-index)
       (loop :for row :from start-row :to end-row :do
-           (let ((date-val (get-value-at sheet row date-index))
-                 (category-val (get-value-at sheet row category-index))
-                 (content-val (get-value-at sheet row content-index)))
-             (if (string= category-val (get-const :category-do))
-                 (cond ((date= date-val today)
-                        (today-contents.push content-val))
-                       ;; Note: Range from start-row to end-row includes only today and next date.
-                       ;; So if a date is not today, it is next date.
-                       (t (next-contents.push content-val)))
-                 (when (date= date-val today)
-                   (check-if-other-category category-val)
-                   (let ((lst (gethash category-val other-contents-table)))
-                     (unless lst (setf lst (list)))
-                     (lst.push content-val)
-                     (setf (gethash category-val other-contents-table) lst)))))))
-    (let ((today-content-text (format-content "やったこと" today-contents))
-          (next-content-text (format-content "次にすること" next-contents))
-          (aggregate-text (format-content "集計" (aggregate today today-contents next-contents)))
-          (other-text ""))
+           (let* ((date-val (get-value-at sheet row date-index))
+                  (category-val (get-value-at sheet row category-index))
+                  (subcategory-val (get-value-at sheet row subcategory-index))
+                  (content-val (get-value-at sheet row content-index))
+                  ;; Note: Range from start-row to end-row includes only today and next date.
+                  ;; So if a date is not today, it is next date.
+                  (target-list (if (date= date-val today)
+                                   today-category-info-list
+                                   next-category-info-list)))
+             (push-content-row :category-info-list target-list
+                               :category category-val
+                               :subcategory subcategory-val
+                               :content content-val))))
+    (let* ( ; today do
+           (today-do-info (find-category-info today-category-info-list
+                                              (get-const :category-do)))
+           (today-content-text (format-content "やったこと" today-do-info))
+           ;; next day do
+           (next-do-info (find-category-info next-category-info-list
+                                             (get-const :category-do)))
+           (next-content-text (format-content "次にすること" next-do-info))
+           ;; aggregate
+           (today-do-contents (category-info-contents today-do-info))
+           (next-do-contents (category-info-contents next-do-info))
+           (aggregate-contents (aggregate today
+                                          today-do-contents
+                                          next-do-contents))
+           (aggregate-category "集計")
+           (aggregate-text "")
+           ;; other
+           (other-text ""))
+      ;; format aggregate
+      (dolist (c aggregate-contents)
+        (push-content-row :category-info-list today-category-info-list
+                          :category aggregate-category
+                          :subcategory ""
+                          :content c))
+      (setf aggregate-text
+            (format-content aggregate-category
+                            (find-category-info today-category-info-list
+                                                aggregate-category)))
+      ;; format others
       (do-other-category (c)
-        (let ((contents (gethash c other-contents-table)))
-          (when contents
+        (let ((category-info (find-category-info today-category-info-list c)))
+          (when category-info
             (setf other-text
                   (+ other-text (format-content
-                                 (get-title-of-category c) contents))))))
+                                 (get-title-of-category c) category-info))))))
       (+ aggregate-text today-content-text next-content-text other-text))))
 
 (defun.ps find-today-and-next-rows (sheet today-date date-index)
@@ -90,13 +122,18 @@
               (t (setf start-row row)))))
     (values start-row end-row)))
 
-(defun.ps format-content (title contents)
-  (when (= contents.length 0)
+(defun.ps format-content (title category-info)
+  (unless category-info
     (return-from format-content ""))
   (let* ((nl #\Newline)
          (res (+ "【" title "】" nl)))
-    (dolist (c contents)
-      (setf res (+ res "- "
-                   (c.replace (regex "/\\n/g") (+ nl "  "))
-                   nl)))
+    (do-subcategory ((name contents) category-info)
+      (let* ((has-name (not (string= name "")))
+             (offset (if has-name "    " "")))
+        (when has-name
+          (setf res (+ res "- " name nl)))
+        (dolist (c contents)
+          (setf res (+ res offset "- "
+                       (c.replace (regex "/\\n/g") (+ nl offset "  "))
+                       nl)))))
     (+ res nl)))

--- a/src/nippo-content.lisp
+++ b/src/nippo-content.lisp
@@ -76,11 +76,7 @@
                                              (get-const :category-do)))
            (next-content-text (format-content "次にすること" next-do-info))
            ;; aggregate
-           (today-do-contents (category-info-contents today-do-info))
-           (next-do-contents (category-info-contents next-do-info))
-           (aggregate-contents (aggregate today
-                                          today-do-contents
-                                          next-do-contents))
+           (aggregate-contents (aggregate today today-do-info next-do-info))
            (aggregate-category "集計")
            (aggregate-text "")
            ;; other


### PR DESCRIPTION
## Summary

You can set subcategories like as the following.

Date | Category | Subcategory | Content
-- | -- | -- | --
2022/08/28 | やること | sub1 | hoge1-1
2022/08/28 | やること | sub1 | hoge1-2
2022/08/28 | やること | sub2 | hoge2-1
2022/08/28 | やること | sub2 | hoge2-2
2022/08/28 | やること | | hoge3

Then mail body will be created as the following.

```txt
- sub1
    - hoge1-1
    - hoge1-2
- sub2
    - hoge2-1
    - hoge2-2
- hoge3
```

## other change (incompatible)

You should specify names of nippo sheet and log sheet in config.